### PR TITLE
Fix: Remove duplicate python-dotenv from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,3 @@ pytest
 openai
 PyYAML
 httpx>=0.25.0
-python-dotenv>=1.0.0


### PR DESCRIPTION
Removes the redundant entry for `python-dotenv` in the `requirements.txt` file.