### PR TITLE
Refactor: Remove redundant logging configuration

### DIFF
--- a/llm_selector.py
+++ b/llm_selector.py
@@ -6,7 +6,6 @@ import logging
 from typing import Dict, Any, Optional, Tuple, List
 
 # Set up logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 class LLMSelector:

--- a/source_manager.py
+++ b/source_manager.py
@@ -6,7 +6,6 @@ import httpx
 from dotenv import load_dotenv
 
 # Set up logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Load environment variables

--- a/utils.py
+++ b/utils.py
@@ -9,7 +9,6 @@ import unicodedata
 import logging
 
 # Set up logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 def remove_control_chars(s: str) -> str:


### PR DESCRIPTION
I've removed unnecessary `logging.basicConfig` calls from `utils.py`, `source_manager.py`, and `llm_selector.py`. The root logger is now configured only in the main entry point (`teamPipeline.py`). I've verified that `logging.getLogger(__name__)` is used in all affected files. I tested the changes by running the pipeline and confirmed that logging still works as expected.