### PR TITLE
Refactor: Remove unused import  from database_functions.py (fixes #31)

### DIFF
--- a/database_functions.py
+++ b/database_functions.py
@@ -1,7 +1,6 @@
 import os
 import logging
 from supabase import create_client, Client  # Import Client
-from urllib.parse import urlparse
 from typing import Dict, Any, Optional, List
 
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
This PR removes the unused `urlparse` import from `database_functions.py`, as mentioned in Issue #31. The import was not used anywhere in the file, and removing it helps clean up the codebase.

Let me know if any other improvements are needed!
